### PR TITLE
Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.9"
+
+services:
+  app:
+    build: .
+    container_name: app_go
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mongo
+    environment:
+      - MONGO_URI=mongodb://mongo:27017/poke_opinion
+
+  mongo:
+    image: mongo:6.0.0
+    container_name: mongo_db
+    restart: always
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
+volumes:
+  mongo_data:

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,28 @@
+
+FROM golang:1.25-alpine AS builder
+
+
+RUN apk add --no-cache git
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+
+RUN go build -o main .
+
+
+FROM alpine:3.20
+
+RUN apk add --no-cache libc6-compat
+
+WORKDIR /root/
+
+COPY --from=builder /app/main .
+
+EXPOSE 8080
+
+CMD ["./main"]


### PR DESCRIPTION
### Deploy com Docker
**Descrição**

Setup para rodar a API Pokémon em Go com MongoDB usando Docker e Docker Compose.

------

**Build e execução**

1. **Build e subir containers:**

```
  docker-compose up --build
```

**2. Acessar a API:**
```
  http://localhost:8080/pokemon/pikachu
```
------
**Parar containers:**
```
 docker-compose down
```

------
Observações

_Contêiner app_go executa a aplicação Go._

Contêiner mongo_db executa MongoDB com persistência via volume mongo_data.

Variável _MONGO_URI_ configurada para conexão interna entre containers.