### PR TITLE
Services

### DIFF
--- a/services/PokemonService.go
+++ b/services/PokemonService.go
@@ -35,3 +35,15 @@ func (s *PokemonService) GetPokemon(name string) (*models.PokemonStats, error) {
 
 	return &pokemon, nil
 }
+
+func (s *PokemonService) AddLikesPokemon(pokemonID primitive.ObjectID) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	update := bson.M{
+		"$inc": bson.M{"likes": 1},
+	}
+
+	_, err := s.Collection.UpdateByID(ctx, pokemonID, update)
+	return  err
+}

--- a/services/PokemonService.go
+++ b/services/PokemonService.go
@@ -3,14 +3,12 @@ package services
 import (
 	"context"
 	"time"
-	
+
 	"github.com/Fsp30/Pokedex_with_golang/models"
 
-	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-
-
-
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type PokemonService struct{
@@ -46,4 +44,19 @@ func (s *PokemonService) AddLikesPokemon(pokemonID primitive.ObjectID) error {
 
 	_, err := s.Collection.UpdateByID(ctx, pokemonID, update)
 	return  err
+}
+
+func (s *PokemonService) AddOpinion(pokemonID primitive.ObjectID, opinion models.Opinion) error{
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	opinion.CreatedAt = time.Now().Unix()
+
+	filter := bson.M{"_id": pokemonID}
+	update := bson.M{
+		"$push" : bson.M{"opinions": opinion},
+	}
+
+	_, err := s.Collection.UpdateOne(ctx, filter, update)
+	return err
 }

--- a/services/PokemonService.go
+++ b/services/PokemonService.go
@@ -1,0 +1,37 @@
+package services
+
+import (
+	"context"
+	"time"
+	
+	"github.com/Fsp30/Pokedex_with_golang/models"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+
+
+)
+
+type PokemonService struct{
+	Collection *mongo.Collection
+}
+
+func (s *PokemonService) InsertPokemon(pokemon models.PokemonStats) (*mongo.InsertOneResult, error){
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return s.Collection.InsertOne(ctx, pokemon)
+}
+
+func (s *PokemonService) GetPokemon(name string) (*models.PokemonStats, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var pokemon models.PokemonStats
+	err := s.Collection.FindOne(ctx, bson.M{"name": name}).Decode(&pokemon)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pokemon, nil
+}

--- a/services/userService.go
+++ b/services/userService.go
@@ -1,0 +1,21 @@
+package services
+
+import (
+	"context"
+	"time"
+	
+	"github.com/Fsp30/Pokedex_with_golang/models"
+
+	"go.mongodb.org/mongo-driver/mongo"
+
+)
+
+type UserService struct {
+	Collection *mongo.Collection
+}
+
+func (s *UserService) CreateUser(user models.User) (*mongo.InsertOneResult, error){
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return s.Collection.InsertOne(ctx, user)
+}


### PR DESCRIPTION
### Serviços MongoDB - Pokedex_with_golang

**Este PR adiciona serviços básicos para interagir com MongoDB em Go.**
---

### Pokémon Service (PokemonService)

`InsertPokemon(pokemon models.PokemonStats) (*mongo.InsertOneResult, error)` – Insere um Pokémon na coleção.

`GetPokemon(name string) (*models.PokemonStats, error)` – Busca um Pokémon pelo nome.

`AddLikesPokemon(pokemonID primitive.ObjectID) error` – Incrementa o número de likes de um Pokémon.

`AddOpinion(pokemonID primitive.ObjectID, opinion models.Opinion) error` – Adiciona uma opinião a um Pokémon.

---
**Usuário Service (UserService)**

`CreateUser(user models.User) (*mongo.InsertOneResult, error)` – Cria um novo usuário na coleção.

**Todos os métodos usam context com timeout de 5 segundos para operações com o MongoDB.**